### PR TITLE
chore: pin GitHub Actions to specific commit SHAs

### DIFF
--- a/.github/workflows/code_quality_checks.yml
+++ b/.github/workflows/code_quality_checks.yml
@@ -23,9 +23,9 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "${{ env.PYTHON_VERSION }}"
 
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           # With the default value of 1, there are corner cases where tj-actions/changed-files
           # fails with a `no merge base` error
@@ -53,14 +53,14 @@ jobs:
 
       - name: Get changed files
         id: files
-        uses: tj-actions/changed-files@v44
+        uses: tj-actions/changed-files@2d756ea4c53f7f6b397767d8723b3a10a9f35bf2 # v44.0.0
         with:
           files: |
             **/*.py
           files_ignore: |
             test/**
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "${{ env.PYTHON_VERSION }}"
 
@@ -70,7 +70,7 @@ jobs:
           pip install hatch==${{ env.HATCH_VERSION }}
           echo "env=$(hatch env find test)" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/cache/restore@v4
+      - uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         id: cache
         with:
           path: ${{ steps.hatch.outputs.env }}


### PR DESCRIPTION
## Summary

- Pin all GitHub Actions in workflow files to immutable full-length commit SHAs instead of mutable tags (e.g. `@v4`, `@v5`)
- Used [pinact](https://github.com/suzuki-shunsuke/pinact) to automatically resolve and apply the correct SHAs
- Version tags are preserved as inline comments for readability (e.g. `# v4.3.1`)

## Motivation

Mutable tags can be silently updated by action authors, which creates a supply chain attack vector. Pinning to a specific commit SHA ensures the exact code being run never changes unexpectedly.
See https://github.com/deepset-ai/haystack-private/issues/137 and https://github.com/deepset-ai/haystack/pull/10896 for more details.
I investigated a bit if the inline comments work with dependabot PRs that update the commit hash.
It seems to work well.

## Affected workflows

- `code_quality_checks.yml` — 6 actions pinned

🤖 Generated with [Claude Code](https://claude.com/claude-code)