### PR TITLE
Fix retrieved_contexts appending itself on a BadRequestError

### DIFF
--- a/evaluations/evaluation_aragog.py
+++ b/evaluations/evaluation_aragog.py
@@ -72,7 +72,7 @@ def run_basic_rag(doc_store, sample_questions, embedding_model, top_k):
             print(f"Error with question: {q}")
             print(e)
             predicted_answers.append("error")
-            retrieved_contexts.append(retrieved_contexts)
+            retrieved_contexts.append([])
 
     return retrieved_contexts, predicted_answers
 

--- a/evaluations/evaluation_sentence_window_retrieval.py
+++ b/evaluations/evaluation_sentence_window_retrieval.py
@@ -80,7 +80,7 @@ def run_rag(rag, questions):
             print(f"Error with question: {q}")
             print(e)
             predicted_answers.append("error")
-            retrieved_contexts.append(retrieved_contexts)
+            retrieved_contexts.append([])
 
     return retrieved_contexts, predicted_answers
 


### PR DESCRIPTION
On a `BadRequestError`, both `evaluation_aragog.py` and `evaluation_sentence_window_retrieval.py` do `retrieved_contexts.append(retrieved_contexts)` — appending the whole running list to itself instead of a placeholder for that question. That makes `retrieved_contexts[i] is retrieved_contexts`, so a single 400 anywhere in a run corrupts the list for every downstream consumer (JSON serialization, pandas conversion, the eval pipeline's `context_relevance`/`faithfulness` inputs), and it falls out of alignment with `predicted_answers`.

Fixed by appending `[]` instead, matching the shape of a successful entry (a list of retrieved document contents) with no context available.

Repro (same bug in both files):
```python
retrieved_contexts.append(retrieved_contexts)
retrieved_contexts[1] is retrieved_contexts  # True
json.dumps(retrieved_contexts)  # ValueError: Circular reference detected
```

No test suite exists in this repo, so I verified with a standalone script reproducing the exact control flow — confirmed the self-reference and `json.dumps` failure before the fix, and confirmed `[["doc for q1"], [], ["doc for q3"]]` (correct shape, index-aligned with `predicted_answers`) after.

`ruff check`/`ruff format --check` both clean.
