### PR TITLE
fix: guard against IndexError when ExtractiveReader returns no answers

### DIFF
--- a/evaluations/evaluation_squad_extractive_qa.py
+++ b/evaluations/evaluation_squad_extractive_qa.py
@@ -76,8 +76,14 @@ def run_extractive_qa(doc_store, questions, embedding_model, top_k_retriever):
         response = extractive_qa.run(
             data={"embedder": {"text": q}, "retriever": {"top_k": top_k_retriever}, "reader": {"query": q, "top_k": 1}}
         )
-        retrieved_docs.append([answer.document for answer in response["reader"]["answers"]])
-        predicted_answers.append(response["reader"]["answers"][0].data)
+        answers = response["reader"]["answers"]
+        retrieved_docs.append([answer.document for answer in answers])
+        try:
+            predicted_answers.append(answers[0].data)
+        except IndexError:
+            print(f"Error with question: {q}")
+            print("Reader returned no answers")
+            predicted_answers.append("error")
 
     return retrieved_docs, predicted_answers
 


### PR DESCRIPTION
`run_extractive_qa()` indexes `response["reader"]["answers"][0]` unconditionally. `ExtractiveReader` returns `{"answers": []}` (not an exception) whenever it gets an empty documents list — that's its own documented behavior, not an edge case. So a single question where the retriever comes back empty crashes the whole SQuAD 2.0 batch eval run.

Fixed with the same try/except pattern this repo already uses for the equivalent per-question failure in `evaluation_aragog.py` and `evaluation_sentence_window_retrieval.py`: log it, record `"error"` as the placeholder, keep going.

Verified against the real `ExtractiveReader` component (same `top_k=1, no_answer=False` config this script uses): confirmed `reader.run(query=..., documents=[])` returns `{"answers": []}`, confirmed the old code raises `IndexError` on that, confirmed the fix catches it and keeps `retrieved_docs`/`predicted_answers` aligned. `ruff check`/`ruff format --check` both clean. No test suite exists in this repo for the evaluation scripts (pure example/demo code), consistent with #21.